### PR TITLE
Adding context key to cdk.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,14 +226,16 @@ Tag.add(infra, K.STAGE, V.STAGE.DEV)
         - 🔸to create SSM|secretmanager values, you will still need to bootstrap by using the cli
 -  scope config values by stage
     ```yaml
-    {
-        "dev": {
-            "account": 1234567,
-            "region": "us-west-2",
-            # ...
-        },
-        "prod": {
-            # ...
+    "config": {
+        {
+            "dev": {
+                "account": 1234567,
+                "region": "us-west-2",
+                # ...
+            },
+            "prod": {
+                # ...
+            }
         }
     }
     ```


### PR DESCRIPTION
@kevinslin ,

I struggled to get CDK to pull in data from `cdk.json` until I found from this doc https://docs.aws.amazon.com/cdk/latest/guide/context.html that it has to be in a `context` key. Thought this might help others