### PR TITLE
fix: Corrected context code

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,16 +226,14 @@ Tag.add(infra, K.STAGE, V.STAGE.DEV)
         - 🔸to create SSM|secretmanager values, you will still need to bootstrap by using the cli
 -  scope config values by stage
     ```yaml
-    "config": {
-        {
-            "dev": {
-                "account": 1234567,
-                "region": "us-west-2",
-                # ...
-            },
-            "prod": {
-                # ...
-            }
+    "context": {
+        "dev": {
+            "account": 1234567,
+            "region": "us-west-2",
+            # ...
+        },
+        "prod": {
+            # ...
         }
     }
     ```


### PR DESCRIPTION
I believe in your code example for config values in `cdk.json` you meant to name the object "context" and not "config", right?

I also eliminated a nested object that was syntactically incorrect.

fixes #5 